### PR TITLE
Fixed some bugs in the SDL2 implementation. Incremented version to 1.2.5

### DIFF
--- a/pyjoystick/__meta__.py
+++ b/pyjoystick/__meta__.py
@@ -1,5 +1,5 @@
 name = 'pyjoystick'
-version = '1.2.4'
+version = '1.2.5'
 description = 'Tools to get Joystick events.'
 url = 'https://github.com/justengel/pyjoystick'
 author = 'Justin Engel'

--- a/pyjoystick/interface.py
+++ b/pyjoystick/interface.py
@@ -373,7 +373,7 @@ class Joystick(object):
         self.get_key(key).set_value(key.value)
 
     def get_id(self):
-        """Return the joystick id."""
+        """Return the joystick instance id."""
         return self.identifier
 
     def get_name(self):

--- a/pyjoystick/sdl2.py
+++ b/pyjoystick/sdl2.py
@@ -216,10 +216,9 @@ def get_guid(joystick):
     Returns:
         guid (str): GUID String.
     """
-    try:
+    # If a pyjoystick Joystick was passed, get the internal SDL_Joystick
+    if isinstance(joystick, BaseJoystick):
         joystick = joystick.joystick
-    except:
-        pass
     guid = sdl2.SDL_JoystickGetGUID(joystick)
     guid_buff = ctypes.create_string_buffer(33)
     sdl2.SDL_JoystickGetGUIDString(guid, guid_buff, ctypes.sizeof(guid_buff))
@@ -685,10 +684,8 @@ class EventLoop:
 
     def stop(self):
         """Try to stop running the event loop."""
-        try:
+        if isinstance(self.alive, threading.Event):
             self.alive.clear()
-        except (AttributeError, Exception):
-            pass
         try:
             stop_event_wait()
         except (AttributeError, Exception):
@@ -696,23 +693,20 @@ class EventLoop:
 
     def run(self):
         """Run the event loop."""
-        try:
+        # Check type because alive can be threading.Event or function
+        if isinstance(self.alive, threading.Event):
             self.alive.set()
-        except (AttributeError, Exception):
-            pass
 
         for event in self:
             self.call_event(event)
 
     def is_alive(self):
         """Return if this event loop is alive and should keep running."""
-        try:
+        if isinstance(self.alive, threading.Event):
             return self.alive.is_set()  # If a threading event
-        except (AttributeError, TypeError, Exception):
-            try:
-                return self.alive()
-            except (AttributeError, TypeError, Exception):
-                return True
+        if callable(self.alive):
+            return self.alive()
+        return True
 
     def __iter__(self):
         """Return this object as an iterator for use with the for loop or next()"""
@@ -792,12 +786,14 @@ class JoystickEventLoop(EventLoop):
     def on_add(self, event):
         assert event.type == sdl2.SDL_JOYDEVICEADDED or event.type == sdl2.SDL_CONTROLLERDEVICEADDED, \
             "on_add event.type should be SDL_JOYDEVICEADDED or SDL_CONTROLLERDEVICEADDED"
+        joy = None
         try:
             # Joystick instance is created inside get_joystick
-            self.add(self.get_joystick(event))
+            joy = self.get_joystick(event)
         except:
             pass
-
+        if joy and callable(self.add):
+            self.add(joy)
 
     # This will be called 2x: once for Joystick and once for GameController if both SDL subsystems are initialized
     # Joysticks that are supported game controllers receive both an SDL_JoyDeviceEvent and an SDL_ControllerDeviceEvent.
@@ -805,16 +801,19 @@ class JoystickEventLoop(EventLoop):
     def on_remove(self, event):
         assert event.type == sdl2.SDL_JOYDEVICEREMOVED or event.type == sdl2.SDL_CONTROLLERDEVICEREMOVED, \
             "on_remove event.type should be SDL_JOYDEVICEREMOVED or SDL_CONTROLLERDEVICEREMOVED"
+        joy = None
         try:
-            self.remove(self.get_joystick(event))
+            joy = self.get_joystick(event)
         except:
             pass
+        if joy and callable(self.remove):
+            self.remove(joy)
 
     # Joysticks that are supported game controllers receive both an SDL_JoyDeviceEvent and an SDL_ControllerDeviceEvent.
     # ControllerEventLoop does not implement its own on_key_event
     def on_key_event(self, event):
         key = self.key_from_event(event, self.get_joystick(event))
-        if key is not None:
+        if key is not None and callable(self.handle_key):
             self.handle_key(key)
 
 

--- a/pyjoystick/sdl2.py
+++ b/pyjoystick/sdl2.py
@@ -1,6 +1,4 @@
 import os
-import sys
-import platform
 import ctypes
 import threading
 
@@ -135,41 +133,52 @@ class Joystick(BaseJoystick):
         except:
             pass
 
+# end of class Joystick(BaseJoystick)
 
-def get_init(*modules):
-    """Return if the given module was initialized."""
-    if len(modules) == 0:
-        modules = (sdl2.SDL_INIT_GAMECONTROLLER, sdl2.SDL_INIT_JOYSTICK)
+def get_init(*subsystems):
+    """Return if all the given subsystems were initialized."""
+    if len(subsystems) == 0:
+        subsystems = (sdl2.SDL_INIT_GAMECONTROLLER, sdl2.SDL_INIT_JOYSTICK)
     was_init = True
-    for module in modules:
-        was_init = was_init and sdl2.SDL_WasInit(module)
+    for subsystem in subsystems:
+        was_init = was_init and sdl2.SDL_WasInit(subsystem)
+        # SDL_WasInit: Get a mask of the specified subsystems which are currently initialized.
+        # (Uint32) Returns a mask of all initialized subsystems if flags is 0, otherwise it returns the initialization status of the specified subsystems.
     return was_init
 
 
-def init(*modules):
-    """Initialize the given module.
+def init(*subsystems):
+    """Initialize the given subsystem(s).
 
     Note:
         SDL_INIT_GAMECONTROLLER also initializes the joystick subsystem.
     """
-    if len(modules) == 0:
-        modules = (sdl2.SDL_INIT_GAMECONTROLLER, sdl2.SDL_INIT_JOYSTICK)
-    for module in modules:
-        if get_init(module):
-            quit(module)
-        sdl2.SDL_Init(module)
+    if len(subsystems) == 0:
+        subsystems = (sdl2.SDL_INIT_GAMECONTROLLER, sdl2.SDL_INIT_JOYSTICK)
+    flags = 0
+    for subsystem in subsystems:
+        flags = flags | subsystem
+    # Subsystem initializations are reference counted. Call SDL_QuitSubSystem as many times as you have called SDL_Init for it.
+    if get_init(flags):
+        sdl2.SDL_QuitSubSystem(flags)
+    # int SDL_Init(Uint32 flags);
+    # Uint32 flags subsystem initialization flags.
+    res = sdl2.SDL_Init(flags)
 
+def quit(*subsystems):
+    """Quit the given subsystem(s).
 
-def quit(*modules):
-    """Quit the given module."""
-    if len(modules) == 0:
-        modules = (sdl2.SDL_INIT_EVERYTHING,)
-    for module in modules:
-        try:
-            sdl2.SDL_QUIT(module)
-        except:
-            pass
-
+    Note:
+        SDL_INIT_GAMECONTROLLER also quits the joystick subsystem.
+    """
+    if len(subsystems) == 0:
+        # Only quit the subsystems pyjoystick is using, not everything
+        subsystems = (sdl2.SDL_INIT_GAMECONTROLLER, sdl2.SDL_INIT_JOYSTICK)
+    flags = 0
+    for subsystem in subsystems:
+        flags = flags | subsystem
+    # SDL_Quit() quits all subsystems, and it doesn't take arguments. SDL_QuitSubSystem(flags) can be used to deinit a single subsystem.
+    sdl2.SDL_QuitSubSystem(flags)
 
 def get_guid(joystick):
     """Return the GUID from the given joystick object.

--- a/pyjoystick/sdl2.py
+++ b/pyjoystick/sdl2.py
@@ -41,6 +41,13 @@ class Joystick(BaseJoystick):
         return Stash(cls(i) for i in range(sdl2.SDL_NumJoysticks()))  # Use identifier not instance id.
 
     def __new__(cls, identifier=None, instance_id=None, *args, **kwargs):
+        """
+        identifier: device index (int) for SDL_JoystickOpen or name (str) for SDL_JoystickName
+        instance_id: SDL_JoystickID (int)
+
+        The term "device_index" identifies currently plugged in joystick devices between 0 and SDL_NumJoysticks(),
+        with the exact joystick behind a device_index changing as joysticks are plugged and unplugged.
+        """
         # Check init
         if not get_init():
             init()
@@ -48,35 +55,45 @@ class Joystick(BaseJoystick):
         # Create the object
         joy = super().__new__(cls)
 
+        # The device_index argument refers to the N'th joystick presently recognized by SDL on the system.
+        # It is NOT the same as the instance ID used to identify the joystick in future events.
+        # device_index should not be stored in the Joystick object because index can change at any time when adding or removing joysticks from the system.
+        device_index = None
+
+        # instance_id: SDL_JoystickID (int)
+        # This is a unique ID for a joystick for the time it is connected to the system, and is never reused for the
+        # lifetime of the application.
         if instance_id is not None:
-            # Create the underlying joystick from the instance id.
+            # Get the underlying joystick from the instance id (does NOT create a new one)
             # SDL_JOYDEVICEREMOVED and all other SDL_JOY#### events give the instance id
             joy.joystick = sdl2.SDL_JoystickFromInstanceID(instance_id)
-            # print('Instance ID:', raw_joystick, SDL_JoystickGetAttached(raw_joystick))
+            # print('Instance ID:', joy.joystick, sdl2.SDL_JoystickGetAttached(joy.joystick))
         else:
             # Create the underlying joystick from the enumerated identifier
             # SDL_JOYDEVICEADDED and SDL_NumJoysticks use open
-            if identifier is None:
+            if identifier is None: # Opens the first enumerated joystick
                 identifier = 0
-            if isinstance(identifier, str):
+            if isinstance(identifier, str): # identifier is joystick name
                 # Get the joystick from the name or None if not found!
                 for i in range(sdl2.SDL_NumJoysticks()):
+                    # Open using device_index (i)
                     raw_joystick = sdl2.SDL_JoystickOpen(i)
                     try:
                         if sdl2.SDL_JoystickName(raw_joystick).decode('utf-8') == identifier:
                             joy.joystick = raw_joystick
-                            instance_id = i
+                            device_index = i
                             break
                     except:
                         pass
-            else:
-                instance_id = identifier
-                joy.joystick = sdl2.SDL_JoystickOpen(identifier)
+            else: # identifier is device_index
+                # Open using device_index
+                device_index = identifier
+                joy.joystick = sdl2.SDL_JoystickOpen(device_index)
             # print('ID:', raw_joystick, SDL_JoystickGetAttached(raw_joystick))
 
         try:
-            joy.identifier = sdl2.SDL_JoystickID(instance_id).value
-            # joy.identifier = SDL_JoystickInstanceID(raw_joystick)
+            # joy.identifier is instance id
+            joy.identifier = sdl2.SDL_JoystickInstanceID(joy.joystick)
             joy.name = sdl2.SDL_JoystickName(joy.joystick).decode('utf-8')
             joy.numaxes = sdl2.SDL_JoystickNumAxes(joy.joystick)
             joy.numbuttons = sdl2.SDL_JoystickNumButtons(joy.joystick)
@@ -87,11 +104,16 @@ class Joystick(BaseJoystick):
             pass
 
         # Try to get the gamepad object
+        # This will only work for actual game pad devices, not for regular joysticks
         try:
-            joy.gamecontroller = sdl2.SDL_GameControllerOpen(joy.identifier)
-            # FromInstanceId does not Attach!
-            # joy.gamecontroller = SDL_GameControllerFromInstanceID(SDL_JoystickInstanceID(joy.joystick)
-            # print('ID:', SDL_GameControllerGetAttached(joy.gamecontroller))
+            if instance_id is not None: # SDL_GameController object should already exist.
+                # Instance ID should be the same as our Joystick instance ID (?) This is not clear in the docs.
+                joy.gamecontroller = sdl2.SDL_GameControllerFromInstanceID(sdl2.SDL_JoystickInstanceID(joy.joystick))
+            else:
+                # Create new SDL_GameController instance with joystick device_index
+                # SDL_GameController* SDL_GameControllerOpen(int joystick_index)
+                # joystick_index is the same as the device_index passed to SDL_JoystickOpen()
+                joy.gamecontroller = sdl2.SDL_GameControllerOpen(device_index)
 
             # Get mapping
             try:
@@ -104,6 +126,7 @@ class Joystick(BaseJoystick):
                 joy.key_mapping = {}
                 joy.controller_mapping = {}
         except:
+            # Joystick probably wasn't a gamepad
             joy.gamecontroller = None
             joy.key_mapping = {}
             joy.controller_mapping = {}

--- a/pyjoystick/sdl2.py
+++ b/pyjoystick/sdl2.py
@@ -42,7 +42,12 @@ class Joystick(BaseJoystick):
         if not get_init(sdl2.SDL_INIT_JOYSTICK):
             init(sdl2.SDL_INIT_JOYSTICK)
 
-        return Stash(cls(i) for i in range(sdl2.SDL_NumJoysticks()))  # Use identifier not instance id.
+        numjoysticks = sdl2.SDL_NumJoysticks()
+        # (int) Returns the number of attached joysticks on success or a negative error code on failure; call SDL_GetError() for more information.
+        # Also seems to return 0 if SDL2 is not initialized.
+        if numjoysticks < 0:
+            raise RuntimeError("SDL_NumJoysticks() error: {}".format(sdl2.SDL_GetError()))
+        return Stash(cls(identifier=i) for i in range(numjoysticks)) # Use identifier (device_index) not instance id.
 
     def __new__(cls, identifier=None, instance_id=None, *args, **kwargs):
         """
@@ -55,6 +60,9 @@ class Joystick(BaseJoystick):
 
         # Should never be uninitialized here since no events are received if SDL2 is not initialized -
         # unless user manually constructs Joystick.
+        # SDL_INIT_JOYSTICK should always be initialized, but SDL_INIT_GAMECONTROLLER not necessarily
+        if not get_init(sdl2.SDL_INIT_JOYSTICK):
+            raise RuntimeError("SDL2 SDL_INIT_JOYSTICK subsystem has not been initialized")
 
         # Create the object
         joy = super().__new__(cls)
@@ -70,7 +78,7 @@ class Joystick(BaseJoystick):
         if instance_id is not None:
             # Get the underlying joystick from the instance id (does NOT create a new one)
             # SDL_JOYDEVICEREMOVED and all other SDL_JOY#### events give the instance id
-            joy.joystick = sdl2.SDL_JoystickFromInstanceID(instance_id)
+            joy.joystick = sdl2.SDL_JoystickFromInstanceID(instance_id) # Returns NULL on errors
             # print('Instance ID:', joy.joystick, sdl2.SDL_JoystickGetAttached(joy.joystick))
         else:
             # Create the underlying joystick from the enumerated identifier
@@ -81,7 +89,7 @@ class Joystick(BaseJoystick):
                 # Get the joystick from the name or None if not found!
                 for i in range(sdl2.SDL_NumJoysticks()):
                     # Open using device_index (i)
-                    raw_joystick = sdl2.SDL_JoystickOpen(i)
+                    raw_joystick = sdl2.SDL_JoystickOpen(i) # Returns NULL on errors
                     try:
                         if sdl2.SDL_JoystickName(raw_joystick).decode('utf-8') == identifier:
                             joy.joystick = raw_joystick
@@ -92,8 +100,14 @@ class Joystick(BaseJoystick):
             else: # identifier is device_index
                 # Open using device_index
                 device_index = identifier
-                joy.joystick = sdl2.SDL_JoystickOpen(device_index)
+                joy.joystick = sdl2.SDL_JoystickOpen(device_index) # Returns NULL on errors
             # print('ID:', raw_joystick, SDL_JoystickGetAttached(raw_joystick))
+        # Check if SDL2 C-functions returned nullptr
+        if not joy.joystick:
+            # err = sdl2.SDL_GetError() # This does not seem to return much useful info
+            # print("Create Joystick failed: {}".format(err.decode()))
+            # Bail out from constructor with an exception to not return incomplete Joystick object
+            raise RuntimeError("SDL_Joystick creation failed: null pointer returned")
 
         try:
             # joy.identifier is instance id
@@ -146,6 +160,7 @@ class Joystick(BaseJoystick):
         """Return if this joystick is still active and available."""
         try:
             return sdl2.SDL_JoystickGetAttached(self.joystick)
+            # Returns SDL_TRUE if the joystick has been opened, SDL_FALSE if it has not; call SDL_GetError() for more information.
         except:
             return False
 
@@ -190,7 +205,10 @@ def init(*subsystems):
         sdl2.SDL_QuitSubSystem(flags)
     # int SDL_Init(Uint32 flags);
     # Uint32 flags subsystem initialization flags.
-    res = sdl2.SDL_Init(flags)
+    res = sdl2.SDL_Init(flags) # Returns 0 on success or a negative error code on failure
+    if res != 0:
+        err = sdl2.SDL_GetError()
+        raise RuntimeError("SDL_Init({}) error: {}".format(flags, err))
 
 def quit(*subsystems):
     """Quit the given subsystem(s).
@@ -706,7 +724,7 @@ class EventLoop:
             return self.alive.is_set()  # If a threading event
         if callable(self.alive):
             return self.alive()
-        return True
+        raise TypeError("Invalid type for alive")
 
     def __iter__(self):
         """Return this object as an iterator for use with the for loop or next()"""

--- a/pyjoystick/sdl2.py
+++ b/pyjoystick/sdl2.py
@@ -740,21 +740,46 @@ class JoystickEventLoop(EventLoop):
 
     def get_joystick(self, event):
         """Return the joystick for this event"""
-        # NOTE: event.jdevice.which is the id to use for SDL_JoystickOpen() and SDL_JoystickFromInstanceID()
+        # NOTE: event.jdevice.which needs careful categorisation because device index is not at all compatible with instance id
+        # struct SDL_JoyDeviceEvent
+        # Sint32 which;       /**< The joystick device index for the ADDED event, instance id for the REMOVED event */
+        # For on_add() identifier = device index
+        if event.type == sdl2.SDL_JOYDEVICEADDED:
+            # print("JS get_joystick SDL_JOYDEVICEADDED")
+            return Joystick(identifier=event.jdevice.which)
+        if event.type == sdl2.SDL_CONTROLLERDEVICEADDED:
+            # print("JS get_joystick SDL_CONTROLLERDEVICEADDED")
+            return Joystick(identifier=event.jdevice.which)
+        # For all other joystick events instance_id = instance id
+        # SDL_JoystickID which; /**< The joystick instance id */
         return Joystick(instance_id=event.jdevice.which)
 
+    # This will be called 2x: once for Joystick and once for GameController if both SDL subsystems are initialized
+    # Joysticks that are supported game controllers receive both an SDL_JoyDeviceEvent and an SDL_ControllerDeviceEvent.
+    # ControllerEventLoop does not implement its own on_add
     def on_add(self, event):
+        assert event.type == sdl2.SDL_JOYDEVICEADDED or event.type == sdl2.SDL_CONTROLLERDEVICEADDED, \
+            "on_add event.type should be SDL_JOYDEVICEADDED or SDL_CONTROLLERDEVICEADDED"
         try:
+            # Joystick instance is created inside get_joystick
             self.add(self.get_joystick(event))
         except:
             pass
 
+
+    # This will be called 2x: once for Joystick and once for GameController if both SDL subsystems are initialized
+    # Joysticks that are supported game controllers receive both an SDL_JoyDeviceEvent and an SDL_ControllerDeviceEvent.
+    # ControllerEventLoop does not implement its own on_remove
     def on_remove(self, event):
+        assert event.type == sdl2.SDL_JOYDEVICEREMOVED or event.type == sdl2.SDL_CONTROLLERDEVICEREMOVED, \
+            "on_remove event.type should be SDL_JOYDEVICEREMOVED or SDL_CONTROLLERDEVICEREMOVED"
         try:
             self.remove(self.get_joystick(event))
         except:
             pass
 
+    # Joysticks that are supported game controllers receive both an SDL_JoyDeviceEvent and an SDL_ControllerDeviceEvent.
+    # ControllerEventLoop does not implement its own on_key_event
     def on_key_event(self, event):
         key = self.key_from_event(event, self.get_joystick(event))
         if key is not None:
@@ -788,7 +813,18 @@ class ControllerEventLoop(JoystickEventLoop):
 
     def get_joystick(self, event):
         """Return the joystick for this event"""
-        # NOTE: event.cdevice.which is the id for SDL_GameControllerOpen() and for SDL_GameControllerFromInstanceID()
+        # NOTE: event.cdevice.which needs careful categorisation because device index is not at all compatible with instance id
+        # struct SDL_ControllerDeviceEvent
+        # Sint32 which; /**< The joystick device index for the ADDED event, instance id for the REMOVED or REMAPPED event */
+        # For on_add() identifier = device index
+        if event.type == sdl2.SDL_JOYDEVICEADDED:
+            # print("GC get_joystick SDL_JOYDEVICEADDED")
+            return Joystick(identifier=event.jdevice.which)
+        if event.type == sdl2.SDL_CONTROLLERDEVICEADDED:
+            # print("GC get_joystick SDL_CONTROLLERDEVICEADDED")
+            return Joystick(identifier=event.cdevice.which)
+        # For all other joystick and gamecontroller events instance_id = instance id
+        # SDL_JoystickID which; /**< The joystick instance id */
         return Joystick(instance_id=event.cdevice.which)
 
     def on_mapped(self, event):

--- a/pyjoystick/sdl2.py
+++ b/pyjoystick/sdl2.py
@@ -34,9 +34,13 @@ __all__ = ['Key', 'Joystick', 'EventLoop', 'JoystickEventLoop', 'ControllerEvent
 class Joystick(BaseJoystick):
     @classmethod
     def get_joysticks(cls):
+        """
+        Note:
+            Initializes SDL2 Joystick submodule, if not already initialized.
+        """
         # Check init
-        if not get_init():
-            init()
+        if not get_init(sdl2.SDL_INIT_JOYSTICK):
+            init(sdl2.SDL_INIT_JOYSTICK)
 
         return Stash(cls(i) for i in range(sdl2.SDL_NumJoysticks()))  # Use identifier not instance id.
 
@@ -48,9 +52,9 @@ class Joystick(BaseJoystick):
         The term "device_index" identifies currently plugged in joystick devices between 0 and SDL_NumJoysticks(),
         with the exact joystick behind a device_index changing as joysticks are plugged and unplugged.
         """
-        # Check init
-        if not get_init():
-            init()
+
+        # Should never be uninitialized here since no events are received if SDL2 is not initialized -
+        # unless user manually constructs Joystick.
 
         # Create the object
         joy = super().__new__(cls)
@@ -712,8 +716,6 @@ class EventLoop:
 
     def __iter__(self):
         """Return this object as an iterator for use with the for loop or next()"""
-        if not get_init():
-            init()
         return self
 
     def __next__(self):
@@ -734,6 +736,8 @@ class JoystickEventLoop(EventLoop):
     def __init__(self, add=None, remove=None, handle_key=None, key_from_event=None,
                  alive=None, event=None, timeout=2000, **kwargs):
         """Initialize the event loop.
+        Note:
+            Also initializes SDL2 Joystick submodule, if not already initialized.
 
         Args:
             add (function/callable)[None]: Function that takes in a joystick on a SDL_JOYDEVICEADDED event.
@@ -760,6 +764,11 @@ class JoystickEventLoop(EventLoop):
         self.register(sdl2.SDL_JOYDEVICEADDED, self.on_add)
         self.register(sdl2.SDL_JOYDEVICEREMOVED, self.on_remove)
         self.register(None, self.on_key_event)  # Every other event
+
+        # Init SDL Joystick
+        # Init only Joystick is enough because gamepads are both joysticks and controllers
+        if not get_init(sdl2.SDL_INIT_JOYSTICK):
+            init(sdl2.SDL_INIT_JOYSTICK)
 
     def get_joystick(self, event):
         """Return the joystick for this event"""
@@ -816,6 +825,8 @@ class ControllerEventLoop(JoystickEventLoop):
     def __init__(self, add=None, remove=None, handle_key=None, key_from_event=None,
                  alive=None, event=None, timeout=2000, **kwargs):
         """Initialize the event loop.
+        Note:
+            Also initializes SDL2 GameController submodule, if not already initialized.
 
         Args:
             add (function/callable)[None]: Function that takes in a joystick on a SDL_JOYDEVICEADDED event.
@@ -833,6 +844,11 @@ class ControllerEventLoop(JoystickEventLoop):
 
         # Register base events
         self.register(sdl2.SDL_CONTROLLERDEVICEREMAPPED, self.on_mapped)
+
+        # Init SDL GameController
+        # Initializing GameController inits both GameController and Joystick subsystems
+        if not get_init(sdl2.SDL_INIT_GAMECONTROLLER):
+            init(sdl2.SDL_INIT_GAMECONTROLLER)
 
     def get_joystick(self, event):
         """Return the joystick for this event"""

--- a/tests/run_async_client.py
+++ b/tests/run_async_client.py
@@ -7,6 +7,9 @@ async def tcp_print_client():
     message = ''
     while message != 'quit':
         data = await reader.read(4096)
+        if not data:
+            print("Server disconnected")
+            break
         message = data.decode('utf-8')
         print(message)
 

--- a/tests/run_async_server.py
+++ b/tests/run_async_server.py
@@ -16,6 +16,10 @@ if __name__ == '__main__':
     devices = Joystick.get_joysticks()
     print("Devices:", devices)
 
+    if not devices:
+        print("No joysticks detected")
+        exit(1)
+
     monitor = devices[0]
     monitor_keytypes = [Key.AXIS]
 
@@ -33,7 +37,9 @@ if __name__ == '__main__':
         for client in cs:
             client.write(msg)
             # await client.drain()
-        await asyncio.gather(*(client.drain() for client in cs), loop=loop)
+        # Changed in version 3.10: Removed the loop parameter.
+        await asyncio.gather(*(client.drain() for client in cs)) # Didn't investigate if this fix alone is really enough, but seems to be working.
+        # await asyncio.gather(*(client.drain() for client in cs), loop=loop) # Pre Python 3.10
         print('\r', str_msg, end=newline, flush=True)
 
 

--- a/tests/test_sdl2_Joystick.py
+++ b/tests/test_sdl2_Joystick.py
@@ -1,0 +1,50 @@
+def test_sdl2_Joystick_constructor():
+    import pyjoystick.sdl2
+
+    t_name = 'Construct without initializing SDL2 first should raise RuntimeError.'
+    try:
+        pyjoystick.sdl2.Joystick()
+        assert False, t_name
+    except RuntimeError as e:
+        # print('Received expected RuntimeError:', e)
+        pass
+
+    t_name = 'SDL2 init should not raise exceptions'
+    try:
+        pyjoystick.sdl2.init()
+    except Exception as e:
+        print(e)
+        assert False, t_name
+
+    t_name = 'SDL2 subsystems should be initialized after calling init()'
+    assert pyjoystick.sdl2.get_init(), t_name
+
+    t_name = 'Construct using invalid instance id should raise RuntimeError.'
+    try:
+        pyjoystick.sdl2.Joystick(instance_id=0)
+        assert False, t_name
+    except RuntimeError as e:
+        # print('Received expected RuntimeError:', e)
+        pass
+
+    t_name = 'Construct using device index 0 should not throw.'
+    t_note = ' This test requires a connected joystick.'
+    try:
+        joystick = pyjoystick.sdl2.Joystick(identifier=0)
+    except RuntimeError as e:
+        print(e)
+        assert False, t_name + t_note
+
+    t_name = 'Construct using device index 0 should not return null pointer.'
+    assert joystick.joystick, t_name + t_note
+
+    t_name = 'Construct using known instance id should not return null pointer.'
+    joystick = pyjoystick.sdl2.Joystick(instance_id=joystick.identifier)
+    assert joystick.joystick, t_name + t_note
+
+if __name__ == '__main__':
+    test_suite_name = 'test_sdl2_Joystick'
+
+    test_sdl2_Joystick_constructor()
+
+    print('{}: All tests finished successfully!'.format(test_suite_name))


### PR DESCRIPTION
- Fixed some tests that were no longer working with current Python versions
- Fixed SDL Quit never being called
- Fixed SDL Joystick instance id and device index mixed up at some points causing weird issues when removing and re-adding joysticks
- Fixed SDL Init was called for all subsystems in SDL2 instead of only joystick and gamecontroller
- Replaced some try / pass all blocks with narrower error handling
  - Too wide exception passes were the cause for masking e.g. the SDL Quit bug in the first place
  - NOTE: There is a risk of breaking some user code by the addition of raising an exception in the Joystick constructor, but only in the case if the user manually calls the Joystick constructor before init. This exception could be removed if not wanted to cause any risk of breaking.
- Added raising exceptions for some basic error cases

There is no intention to make API breaking changes. But I'm not very experienced user of pyjoystick, so I might be missing some use cases.
As I see it the only possible breaking change is the new exception in Joystick constructor. Per my understanding this constructor should not be needed to be called manually. The exception only happens if user did not init SDL2 Joystick submodule earlier.